### PR TITLE
refactor(frontend): deduplicate API base URL configuration

### DIFF
--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { BASE_URL } from "@/lib/api/client";
 import { useRouter } from "next/navigation";
 import AuthCardShell, {
   AuthCardInner,
@@ -11,11 +12,6 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, CheckCircle2, ArrowLeft, Loader2 } from "lucide-react";
-
-const BASE_URL =
-  process.env.NEXT_PUBLIC_GATEWAY ??
-  process.env.NEXT_PUBLIC_API_URL ??
-  "http://localhost:8080";
 
 const INPUT_CLASS =
   "h-[50px] rounded-[13px] border border-[rgba(209,207,201,0.9)] dark:border-darkcardborder bg-[#F2F1EE] dark:bg-white/5 px-4 font-sans font-medium text-[14px] text-ink dark:text-white shadow-none focus-visible:ring-2 focus-visible:ring-saral-forest/30 focus-visible:border-saral-forest placeholder:text-ink-faint dark:placeholder:text-white/40";
@@ -50,8 +46,8 @@ export default function ForgotPasswordPage() {
         const data = await res.json().catch(() => ({}));
         setError(
           data?.error?.message ??
-            data?.message ??
-            "Too many attempts. Please try again later.",
+          data?.message ??
+          "Too many attempts. Please try again later.",
         );
         return;
       }

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { BASE_URL } from "@/lib/api/client";
 import { useRouter } from "next/navigation";
 import {
   GoogleAuthProvider,
@@ -37,11 +38,6 @@ import {
   Eye,
   EyeOff,
 } from "lucide-react";
-
-const BASE_URL =
-  process.env.NEXT_PUBLIC_GATEWAY ??
-  process.env.NEXT_PUBLIC_API_URL ??
-  "http://localhost:8080";
 
 // ── Provider instances (unchanged) ─────────────────────────────────────────────
 const googleProvider = new GoogleAuthProvider();
@@ -194,7 +190,7 @@ export default function LoginPage() {
           if (!existingProviderId || !existingProvider) {
             setError(
               "This email is already registered with a different sign-in method. " +
-                "Try Google, GitHub, or Microsoft — whichever you used first.",
+              "Try Google, GitHub, or Microsoft — whichever you used first.",
             );
             setLoadingId(null);
             return;
@@ -262,8 +258,8 @@ export default function LoginPage() {
         } else {
           setEmailError(
             data?.error?.message ??
-              data?.message ??
-              "Sign-in failed. Please try again.",
+            data?.message ??
+            "Sign-in failed. Please try again.",
           );
         }
         return;

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -120,13 +120,11 @@ export default function LoginPage() {
 
   const finishLogin = async (user: import("firebase/auth").User) => {
     const token = await user.getIdToken();
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"}/auth/login`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token }),
-      },
+    const res = await fetch(`${BASE_URL}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    },
     );
     if (!res.ok) throw new Error("Authentication failed. Please try again.");
     const data = await res.json();

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -7,6 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import AuthCardShell, {
   AuthCardInner,
 } from "@/components/auth/auth-card-shell";
+import { BASE_URL } from "@/lib/api/client";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -20,11 +21,6 @@ import {
   Loader2,
   XCircle,
 } from "lucide-react";
-
-const BASE_URL =
-  process.env.NEXT_PUBLIC_GATEWAY ??
-  process.env.NEXT_PUBLIC_API_URL ??
-  "http://localhost:8080";
 
 const INPUT_CLASS =
   "h-[50px] rounded-[13px] border border-[rgba(209,207,201,0.9)] dark:border-darkcardborder bg-[#F2F1EE] dark:bg-white/5 px-4 font-sans font-medium text-[14px] text-ink dark:text-white shadow-none focus-visible:ring-2 focus-visible:ring-saral-forest/30 focus-visible:border-saral-forest placeholder:text-ink-faint dark:placeholder:text-white/40";

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/lib/auth-store";
 import AuthShell from "@/components/auth/auth-shell";
 import { Input } from "@/components/ui/input";
+import { BASE_URL } from "@/lib/api/client";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
@@ -16,11 +17,6 @@ import {
   Loader2,
   XCircle,
 } from "lucide-react";
-
-const BASE_URL =
-  process.env.NEXT_PUBLIC_GATEWAY ??
-  process.env.NEXT_PUBLIC_API_URL ??
-  "http://localhost:8080";
 
 const INPUT_CLASS =
   "h-[50px] rounded-[13px] border border-[rgba(209,207,201,0.9)] dark:border-darkcardborder bg-[#F2F1EE] dark:bg-white/5 px-4 font-sans font-medium text-[14px] text-ink dark:text-white shadow-none focus-visible:ring-2 focus-visible:ring-saral-forest/30 focus-visible:border-saral-forest placeholder:text-ink-faint dark:placeholder:text-white/40";

--- a/frontend/components/auth/auth-shell.tsx
+++ b/frontend/components/auth/auth-shell.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { auth, isFirebaseConfigured } from "@/lib/firebase";
 import { useAuthStore } from "@/lib/auth-store";
+import { BASE_URL } from "@/lib/api/client";
 import {
   GoogleIcon,
   MicrosoftIcon,
@@ -58,12 +59,10 @@ export default function AuthShell({
           "Firebase is not configured. Add the NEXT_PUBLIC_FIREBASE_* environment variables and restart the dev server.",
         );
       }
-
       const result = await signInWithPopup(auth, provider);
       const token = await result.user.getIdToken();
-
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"}/auth/login`,
+        `${BASE_URL}/auth/login`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
# Refactor frontend authentication pages to use shared API base URL

**Reviewer:** @handle

**Type:** `[ ] Feature` `[ ] Bug Fix` `[x] Refactor` `[ ] Docs/Config` `[ ] Hotfix`

**Breaking change?** `[ ] Yes` `[x] No`

---

## Summary

This PR removes duplicated `BASE_URL` declarations across the frontend authentication pages and replaces them with the shared `BASE_URL` exported from `frontend/lib/api/client.ts`.

By centralizing the API base URL configuration, this refactor reduces code duplication, improves maintainability, and ensures future API endpoint changes only need to be made in one place. No functional behavior is intended to change.

---

## Rough Example / Context

**Before**

```ts
const BASE_URL =
  process.env.NEXT_PUBLIC_GATEWAY ??
  process.env.NEXT_PUBLIC_API_URL ??
  "http://localhost:8080";
```

The same configuration was duplicated across multiple authentication pages.

**After**

```ts
import { BASE_URL } from "@/lib/api/client";
```

All authentication pages now use the shared configuration from a single source.

---

## How to test locally

```bash
git checkout chore/dedupe-api-base-url

npm install

npm run lint

npx tsc --noEmit

npm run build
```

Verify that:

- Login page builds successfully.
- Signup page builds successfully.
- Forgot Password page builds successfully.
- Reset Password page builds successfully.
- Authentication requests continue using the shared `BASE_URL`.

---

## Checklist

> Tick only what you've actually done.

### Always

- [x] Read through my own diff on GitHub before raising this
- [x] No commented-out code, `console.log`, or debug artifacts left in
- [x] No hardcoded URLs, tokens, or env-specific strings — use `.env`
- [ ] If anything changed in how the project runs, README is updated

### Frontend

- [x] Searched the codebase — this component doesn't already render somewhere else
- [ ] Tested error state, empty state, and loading state — not just the happy path
- [ ] Screenshots below for every visible change

### Backend / API

- [ ] Auth is enforced on new endpoints — no unprotected routes
- [ ] Inputs are validated — no raw user data hitting the DB or external services
- [ ] Errors return proper HTTP status codes
- [ ] No sensitive data in responses — no stack traces, internal IDs, raw DB errors
- [ ] Rate limiting considered for any user-facing or polling-heavy endpoint
- [ ] Frontend handles backend being unreachable — no blank screens or silent failures

### Docs / Config

- [ ] New or changed env vars listed below
- [x] Nothing sensitive committed — keys, tokens, internal URLs

---

## Screenshots _(required for any UI change)_

**N/A – This PR does not introduce any visible UI changes.**

---

## Env vars added or changed _(if any)_

None.

---

## AI pre-review

- [ ] Done

**What it flagged:** N/A

**What I fixed:** N/A

**What I pushed back on (and why):** N/A

---

## Anything the reviewer should know

This is a refactoring-only change. No functional behavior is intended to change.

Validation completed:

- ✅ `npm run lint` (existing repository warnings only; no new lint errors)
- ✅ `npx tsc --noEmit`
- ✅ `npm run build`